### PR TITLE
Add tests, improve code imports by delaying full initialization of vault secrets until needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # Vaultpy
-A module to parse injected [Vault](https://www.vaultproject.io/) secrets and track their usage with Datadog.
+Parse injected [Vault](https://www.vaultproject.io/) secrets and track their usage with Datadog.
 
 ## Requirements
 - Local Datadog agent
-- Environment variables to access it
 - Set [container annotations](https://www.vaultproject.io/docs/platform/k8s/injector/annotations) to inject Vault secrets in K8s
 
 ## Setup
-For production, use the `VAULT_SECRETS_PATH` environment variable to set the path to the secrets that are injected by the Vault Agent in Kubernetes.
+For production, use the `VAULTPY_SECRETS_PATH` environment variable to set the path to the secrets that are injected by the Vault Agent in Kubernetes. This defaults to `/vault/secrets/secrets`. You will also need to set `VAULTPY_ENABLE_VAULT` (default `false`) to use injected secrets rather than loading them from a `de_secrets` module.
 
 For local development, a `de_secrets.py` can be used to load secrets in a format not unlike Django settings.
+
+Lastly you can toggle secret access tracking with Datadog via `VAULTPY_DATADOG_ENABLE`. This defaults to `true` because we want this in production, but it ought to be disabled in development environments.
 
 ## Usage
 Import `vault.secrets` and then access the loaded secrets using by accessing dynamic properties loaded into the `secrets` object (i.e. `secrets.FOO`).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = vaultpy
-version = 0.0.7
+version = 0.1.0
 author = Tim Loyer
 author_email = tloyer@apps.directemployers.org
 description = A module to parse injected Vault secrets and track their usage with Datadog.

--- a/vault/__init__.py
+++ b/vault/__init__.py
@@ -2,18 +2,18 @@ import logging
 from base64 import b64decode, b64encode
 from importlib import import_module
 from json import loads
-from typing import Dict
+from typing import Callable, Dict
 
 from datadog import statsd
 
-from . import config
+from vault import config
 
 logger = logging.getLogger(__name__)
 
 
-def _is_base64(s):
+def _is_base64(s: str) -> bool:
     """
-    Checks whether a sting has been base 64 encoded.
+    Checks whether a string has been base 64 encoded.
     """
     try:
         return b64encode(b64decode(s)) == bytes(s, "utf-8")
@@ -41,8 +41,15 @@ def _load_vault_secrets() -> Dict:
     if _is_base64(contents):
         contents = b64decode(contents)
 
-    contents = loads(contents)
+    return _parse_json_secrets(contents)
 
+
+def _parse_json_secrets(json_contents: str) -> Dict:
+    """
+    Handles regular JSON strings and also JSON strings that adhere to Vault's secret
+    struct format by looking for `data` objects to access.
+    """
+    contents = loads(json_contents)
     try:
         # If the injected secret is formatted as a Vault Secret struct,
         # the actual secrets will be nested under two `data` keys.
@@ -59,6 +66,9 @@ def _get_secrets() -> Dict:
     Get secrets from de_secrets.py in local dev, or from Vault injected secrets file
     located at path in VAULT_SECRETS_PATH. Performs base 64 decode followed by JSON
     decode on file contents.
+
+    This is passed to VaultSecretsWrapper as a callable to delay loading of files
+    and modules until configuration has been set in code.
     """
     if not config.ENABLE_VAULT:
         # Use dev secrets when available.
@@ -72,9 +82,20 @@ class VaultSecretsWrapper:
     Provide access to secrets as attributes and send secret-usage analytics to Datadog.
     """
 
-    def __init__(self, secrets: Dict):
-        self._keys = secrets.keys()
+    def __init__(self, secrets_loader: Callable):
+        """
+        VaultSecretsWrapper takes a callable (secrets_loader) which will return a
+        dictionary of secrets when called. This is to prevent vaultpy from fully
+        initializing until the first secret it returned, which prevents code running
+        before the configuration has been set (i.e. in testing).
+        """
+        self._secrets_loader = secrets_loader
+        self._keys = None
 
+    def _load_secrets(self):
+        secrets = self._secrets_loader()
+
+        self._keys = secrets.keys()
         for key, value in secrets.items():
             # Set baseline usage of 0 for all secrets.
             self._record_usage(key)
@@ -101,7 +122,12 @@ class VaultSecretsWrapper:
         Override the default getattribute method so that we can track secret key
         usage with Datadog. Non-secret attributes are passed on to the default method.
         """
-        if key != "_keys" and key in self._keys:
+        ignored_keys = ["_keys", "_load_secrets", "_secrets_loader"]
+
+        if key not in ignored_keys and self._keys is None:
+            self._load_secrets()
+
+        if key not in ignored_keys and key in self._keys:
             try:
                 self._record_usage(key, 1)
                 return super().__getattribute__(key)
@@ -112,5 +138,5 @@ class VaultSecretsWrapper:
         return super().__getattribute__(key)
 
 
-secrets = VaultSecretsWrapper(_get_secrets())
+secrets = VaultSecretsWrapper(_get_secrets)
 __all__ = ("secrets",)

--- a/vault/tests/data/de_test_secrets.py
+++ b/vault/tests/data/de_test_secrets.py
@@ -1,0 +1,1 @@
+SUPER_SECRET_KEY = "shhhhh!"

--- a/vault/tests/data/secrets_json
+++ b/vault/tests/data/secrets_json
@@ -1,0 +1,1 @@
+{"SUPER_SECRET_KEY": "shhhhh!"}

--- a/vault/tests/data/secrets_json_b64
+++ b/vault/tests/data/secrets_json_b64
@@ -1,0 +1,1 @@
+eyJTVVBFUl9TRUNSRVRfS0VZIjogInNoaGhoaCEifQo=

--- a/vault/tests/helpers.py
+++ b/vault/tests/helpers.py
@@ -1,0 +1,27 @@
+import os
+from typing import Dict
+
+
+def override_env(envs: Dict):
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            restore_envs = {}
+
+            for env, new_val in envs.items():
+                if env in os.environ.keys():
+                    restore_envs[env] = os.environ.get(env)
+                os.environ[env] = new_val
+
+            result = func(*args, **kwargs)
+
+            for env in envs.keys():
+                if env in restore_envs:
+                    os.environ[env] = restore_envs[env]
+                else:
+                    del os.environ[env]
+
+            return result
+
+        return wrapper
+
+    return decorator

--- a/vault/tests/test_configuration.py
+++ b/vault/tests/test_configuration.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+from vault import config
+
+
+class ConfigParsingTest(TestCase):
+    def test_config_defaults(self):
+        defaults = {
+            "VAULTPY_ENABLE_VAULT": False,
+            "VAULTPY_SECRETS_PATH": "/vault/secrets/secrets",
+            "VAULTPY_ENABLE_DATADOG": True,
+        }
+
+        for setting, default in defaults.items():
+            actual_setting = getattr(config, setting.replace("VAULTPY_", ""))
+            self.assertEqual(
+                actual_setting,
+                default,
+                f"{setting} should be `{default}` but was `{actual_setting}`",
+            )

--- a/vault/tests/test_helpers.py
+++ b/vault/tests/test_helpers.py
@@ -1,10 +1,11 @@
 from base64 import b64encode
+from json import dumps
 from unittest import TestCase
 
-from vault import _is_base64
+from vault import _is_base64, _parse_json_secrets
 
 
-class SecretParsingTest(TestCase):
+class HelperFunctionsTest(TestCase):
     def test_is_base64(self):
         test_string = "this will be base64 encoded"
         test_encoded = b64encode(bytes(test_string, "utf-8")).decode("utf-8")
@@ -13,3 +14,28 @@ class SecretParsingTest(TestCase):
     def test_is_not_base64(self):
         test_string = "this will be base64 encoded"
         self.assertFalse(_is_base64(test_string))
+
+    def test_json_parsing(self):
+        """
+        JSON objects may by simple key -> value objects, or adhere to some form of
+        Vault's own Secret struct format (which nests object content in `data` objects).
+        """
+        plain_secret = {"SECRET_KEY": "secret value"}
+        data_secret = {"data": plain_secret}
+        ddata_secret = {"data": data_secret}
+
+        # Not a thing, should yield a dict that looks like {data: {SECRET_KEY: ...}}.
+        dddata_secret = {"data": ddata_secret}
+
+        # Tests expected test cases where secrets are either top level or under up to
+        # two levels of `data` keys.
+        for secrets in [plain_secret, data_secret, ddata_secret]:
+            secrets = dumps(secrets)
+            parsed = _parse_json_secrets(secrets)
+            self.assertEqual(plain_secret, parsed)
+
+        # Tests the case where our expected secrets are under three levels of `data`
+        # keys, which would result in `data` being a top-level dictionary key.
+        secrets = dumps(dddata_secret)
+        parsed = _parse_json_secrets(secrets)
+        self.assertEqual(data_secret, parsed)

--- a/vault/tests/test_helpers.py
+++ b/vault/tests/test_helpers.py
@@ -1,0 +1,15 @@
+from base64 import b64encode
+from unittest import TestCase
+
+from vault import _is_base64
+
+
+class SecretParsingTest(TestCase):
+    def test_is_base64(self):
+        test_string = "this will be base64 encoded"
+        test_encoded = b64encode(bytes(test_string, "utf-8")).decode("utf-8")
+        self.assertTrue(_is_base64(test_encoded))
+
+    def test_is_not_base64(self):
+        test_string = "this will be base64 encoded"
+        self.assertFalse(_is_base64(test_string))

--- a/vault/tests/test_secret_handling.py
+++ b/vault/tests/test_secret_handling.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from vault.tests.data import de_test_secrets
 from vault.tests.helpers import override_env
+from vault import _parse_json_secrets
 
 TEST_DATA_PATH = Path.cwd().joinpath("data")
 TEST_SECRET = "shhhhh!"
@@ -13,6 +14,11 @@ class SecretLoaderTest(TestCase):
     @override_env({"VAULTPY_ENABLE_VAULT": "false", "VAULTPY_ENABLE_DATADOG": "false"})
     @patch("vault.import_module")
     def test_de_secrets_module(self, mock_import):
+        """
+        Test that vaultpy can get secrets from de_secrets.py when
+        VAULTPY_ENABLE_VAULT is false. For testing purposes, de_secrets module is
+        mocked from tests/data/de_test_secrets.py for this test.
+        """
         from vault import secrets
 
         mock_import.return_value = de_test_secrets
@@ -26,6 +32,9 @@ class SecretLoaderTest(TestCase):
         }
     )
     def test_json_secrets(self):
+        """
+        Test injected secrets that are JSON formatted.
+        """
         from vault import secrets
 
         self.assertEqual(TEST_SECRET, secrets.SUPER_SECRET_KEY)
@@ -38,6 +47,9 @@ class SecretLoaderTest(TestCase):
         }
     )
     def test_json_base64_secrets(self):
+        """
+        Test injected secrets that are JSON formatted and Base 64 encoded.
+        """
         from vault import secrets
 
         self.assertEqual(TEST_SECRET, secrets.SUPER_SECRET_KEY)

--- a/vault/tests/test_secret_handling.py
+++ b/vault/tests/test_secret_handling.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from vault.tests.data import de_test_secrets
+from vault.tests.helpers import override_env
+
+TEST_DATA_PATH = Path.cwd().joinpath("data")
+TEST_SECRET = "shhhhh!"
+
+
+class SecretLoaderTest(TestCase):
+    @override_env({"VAULTPY_ENABLE_VAULT": "false", "VAULTPY_ENABLE_DATADOG": "false"})
+    @patch("vault.import_module")
+    def test_de_secrets_module(self, mock_import):
+        from vault import secrets
+
+        mock_import.return_value = de_test_secrets
+        self.assertEqual(TEST_SECRET, secrets.SUPER_SECRET_KEY)
+
+    @override_env(
+        {
+            "VAULTPY_ENABLE_VAULT": "true",
+            "VAULTPY_ENABLE_DATADOG": "false",
+            "VAULTPY_SECRETS_PATH": str(TEST_DATA_PATH.joinpath("secrets_json")),
+        }
+    )
+    def test_json_secrets(self):
+        from vault import secrets
+
+        self.assertEqual(TEST_SECRET, secrets.SUPER_SECRET_KEY)
+
+    @override_env(
+        {
+            "VAULTPY_ENABLE_VAULT": "true",
+            "VAULTPY_ENABLE_DATADOG": "false",
+            "VAULTPY_SECRETS_PATH": str(TEST_DATA_PATH.joinpath("secrets_json_base64")),
+        }
+    )
+    def test_json_base64_secrets(self):
+        from vault import secrets
+
+        self.assertEqual(TEST_SECRET, secrets.SUPER_SECRET_KEY)


### PR DESCRIPTION
- Update readme with new env var names and more explanation of them.
- Test suites added! I've been running with `python3 -m unittest discover -s vault/tests` to avoid complaints about missing a `de_secrets` module.
- Extracted JSON parsing into separate method for easier testing
- VaultSecretsWrapper class now accepts a callable that returns a dictionary rather than the dictionary itself. This was needed so that importing of module in vaultpy didn't result in the package running all its code. Vaultpy will now initialize the first time a secret is retrieved from the wrapper class.
